### PR TITLE
Fix: iconv was build as php static module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir -p /home/default /opt/etc /opt/bin/container-entrypoint.d /opt/src /va
                                                 libzip-dev openldap-dev pcre-dev gnupg git bzip2-dev \
                                                 musl-libintl postgresql-dev libxml2-dev \
     && docker-php-ext-configure gd --with-freetype --with-webp --with-jpeg \
-    && docker-php-ext-install -j "$(nproc)" soap iconv bz2 fileinfo gettext intl pcntl pgsql \
+    && docker-php-ext-install -j "$(nproc)" soap bz2 fileinfo gettext intl pcntl pgsql \
                                             pdo_pgsql simplexml ldap gd ldap mysqli pdo_mysql \
                                             zip opcache bcmath exif \
     && pecl install APCu-5.1.19 \


### PR DESCRIPTION
in parent Docker image, it is no longer required to build it.