### PR TITLE
fix: apache mutex config for multi-process environment

### DIFF
--- a/etc/apache2/httpd.conf
+++ b/etc/apache2/httpd.conf
@@ -47,7 +47,7 @@ ServerRoot /var/www
 # mutex file directory is not on a local disk or is not appropriate for some
 # other reason.
 #
-Mutex sem
+# Mutex default:/run/apache2
 
 #
 # Listen: Allows you to bind Apache to specific IP addresses and/or

--- a/etc/apache2/httpd.conf
+++ b/etc/apache2/httpd.conf
@@ -47,7 +47,7 @@ ServerRoot /var/www
 # mutex file directory is not on a local disk or is not appropriate for some
 # other reason.
 #
-# Mutex default:/run/apache2
+Mutex sem
 
 #
 # Listen: Allows you to bind Apache to specific IP addresses and/or

--- a/etc/supervisord.apache/supervisord.conf
+++ b/etc/supervisord.apache/supervisord.conf
@@ -8,7 +8,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm]
-command=php-fpm -F -R
+command=php-fpm -F -R -DMutex=$$(python -c "import os; print(os.environ.get('APACHE_MUTEX', 'sem'))")
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
as we are mainly using PHP-FPM which one handle PHP processes in dependently, it's recommanded to explicitly activate a multi-process Mutex  such as `sem` or `file:`. And as the `Mutex file:${filename}` is not supported on all hardware architecture (such as Apple Silicon).   Other Mutex like `pthread` or `apr` are recommanded for multi-threading environments.